### PR TITLE
Multi-thread Audio Conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Before you can train a model on the Common Voice dataset, you must first convert
 > **_NOTE:_** Make sure you have `ffmpeg` installed on your computer, as it uses that to convert mp3 to wav
 
 ```
-./scripts/common_voice_convert.sh <data_dir>
+./scripts/common_voice_convert.sh <data_dir> <# of threads>
 python scripts/remove_missing_samples.py \
     --data_dir <data_dir> \
     --replace_old

--- a/scripts/common_voice_convert.sh
+++ b/scripts/common_voice_convert.sh
@@ -5,16 +5,22 @@ IFS=$'\n'
 
 FORMAT=.mp3
 DATA_DIR="$1"
+N=${2:-1}
 
 mkdir -p $DATA_DIR
 
 FILES=$(ls "$DATA_DIR" | grep $FORMAT)
 
+thread () {
+    local FILE_N=$1
+    FILENAME="${FILE_N:0:${#FILE_N}-4}"
+    ffmpeg -i $DATA_DIR/$FILE_N -acodec pcm_s16le -ac 1 -ar 16000 $DATA_DIR/$FILENAME.wav
+    rm $DATA_DIR/$FILE_N
+}
 for FILE in $FILES
 do
-    FILENAME="${FILE:0:${#FILE}-4}"
-    ffmpeg -i $DATA_DIR/$FILE -acodec pcm_s16le -ac 1 -ar 16000 $DATA_DIR/$FILENAME.wav
-    rm $DATA_DIR/$FILE
+   ((i=i%N)); ((i++==0)) && wait
+   thread "$FILE" & 
 done
 
 IFS="$OIFS"


### PR DESCRIPTION
The original script was not that efficient. I added in modifications to allow the conversion loop to run concurrently on multiple threads. A second command-line argument now allows the user to specify a thread count, with the default being single-threaded. This significantly reduces the time needed to prepare the dataset.