### PR TITLE
Fix tensorflow-datasets version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydub>=0.23.1
 scipy>=1.3.1
 tqdm
-tensorflow-datasets
+tensorflow-datasets==3.1.0
 soundfile
 librosa
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pydub>=0.23.1
 scipy>=1.3.1
 tqdm
-tensorflow-datasets==3.1.0
+tensorflow-datasets
 soundfile
 librosa
 matplotlib

--- a/utils/encoding.py
+++ b/utils/encoding.py
@@ -75,9 +75,10 @@ def get_encoder(encoder_dir,
         encoder_filepath = os.path.join(encoder_dir, encoder_filename)
 
         if os.path.exists('{}.subwords'.format(encoder_filepath)):
-            encoder = tfds.features.text.SubwordTextEncoder.load_from_file(encoder_filepath)
+            
+            encoder = tfds.core.deprecated.text.SubwordTextEncoder.load_from_file(encoder_filepath)
         else:
-            encoder = tfds.features.text.SubwordTextEncoder.build_from_corpus(
+            encoder = tfds.core.deprecated.text.SubwordTextEncoder.build_from_corpus(
                 corpus_generator=preprocessed_gen(),
                 target_vocab_size=hparams[HP_VOCAB_SIZE.name])
             os.makedirs(encoder_dir, exist_ok=True)


### PR DESCRIPTION
Hi I'm muramasa from Japan.
I found the bug related to tensorflow-datasets library's version.

```
$ python preprocess_common_voice.py --data_dir input --output_dir preprocess


Traceback (most recent call last):
  File "preprocess_common_voice.py", line 97, in <module>
    app.run(main)
  File "/usr/local/lib/python3.7/site-packages/absl/app.py", line 300, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.7/site-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "preprocess_common_voice.py", line 60, in main
    texts_generator=texts_gen)
  File "/rnnt-speech-recognition/utils/encoding.py", line 80, in get_encoder
    encoder = tfds.features.text.SubwordTextEncoder.build_from_corpus(
AttributeError: module 'tensorflow_datasets.core.features' has no attribute 'text'
```

After that, I found that the tfds.features.text encoding API was deprecated after v3.2.0.(https://github.com/tensorflow/datasets/releases)
So I fix the ver of tensorflow-datasets==3.1.0 in requirements.txt, and it works.

Please merge this PR.