### PR TITLE
fix run_evaluate bug, delete gpus pram

### DIFF
--- a/run_rnnt.py
+++ b/run_rnnt.py
@@ -566,8 +566,7 @@ def main(_):
                 batch_size=FLAGS.batch_size,
                 hparams=hparams,
                 strategy=strategy,
-                metrics=[accuracy_fn, wer_fn],
-                gpus=gpus)
+                metrics=[accuracy_fn, wer_fn])
 
             validation_log_str = 'VALIDATION RESULTS: Time: {:.4f}, Loss: {:.4f}'.format(
                 time.time() - eval_start_time, eval_loss)


### PR DESCRIPTION
Hi I'm muramasa from Japan.
I found the bug in `run_evaluate` function.

```
$ python run_rnnt.py --mode test --data_dir /data ...

Traceback (most recent call last):
  File "run_rnnt.py", line 589, in <module>
    app.run(main)
  File "/usr/local/lib/python3.7/dist-packages/absl/app.py", line 303, in run
    _run_main(main, args)
  File "/usr/local/lib/python3.7/dist-packages/absl/app.py", line 251, in _run_main
    sys.exit(main(argv))
  File "run_rnnt.py", line 572, in main
    gpus=gpus)
NameError: name 'gpus' is not defined
```

the `gpus` option in `run_evaluate` function isn't used, so I deleted it.
Please check and merge this PR.